### PR TITLE
Add cppcheck

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -1,0 +1,13 @@
+name: C++ Static code analysis
+
+on: [push, pull_request]
+
+jobs:
+  cppcheck:
+    name: run-cppcheck
+    runs-on: ubuntu-latest
+    container:
+      image: facthunder/cppcheck:latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: cppcheck --error-exitcode=1 .


### PR DESCRIPTION
@maoo, I included [cppcheck](https://cppcheck.sourceforge.io/) for C++ static code analyses. I am not sure if `semgrep` it makes sense for us as our `java` and `javascript` files are only example projects to use SymphonyMediaBridge

https://github.com/RicardoMDomingues/SymphonyMediaBridge/actions/runs/3496537854/jobs/5854562455